### PR TITLE
V1.3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 - 查看用户登录、登出、操作记录
 
-官网地址：[官网 | Amprobe (amprobe.amuluze.com)](https://amprobe.amuluze.com/)
+官网地址：[官网 | Amprobe (amprobe.amuluze.com)](https://amprobe.amuluze.com/official/)
 
 > **docker 版本要求：>= 20.10.9**
 

--- a/amprobe/Makefile
+++ b/amprobe/Makefile
@@ -28,7 +28,7 @@ wire:
 
 .PHONY: bin
 # build bin
-bin: wire
+bin:
 	$(GO) build $(BUILD_FLAGS) -o $(APP) $(SERVER)
 
 .PHONY: amd64

--- a/amprobe/nginx/conf.d/amprobe.conf.back
+++ b/amprobe/nginx/conf.d/amprobe.conf.back
@@ -1,6 +1,10 @@
 server {
-    listen       80;
-    server_name _;
+    listen       443 ssl;
+    listen       [::]:443 ssl;
+    server_name  amprobe.amuluze.com; # 服务器地址或绑定域名
+
+    ssl_certificate /app/cert/fullchain.pem;
+    ssl_certificate_key /app/cert/privkey.pem;
 
     location / {
         proxy_set_header Host $host;
@@ -18,3 +22,10 @@ server {
         proxy_set_header Connection "upgrade";
     }
 }
+
+server {
+    listen       80;
+    server_name amprobe.amuluze.com;
+    return 301 https://$server_name$request_uri;
+}
+

--- a/amprobe/service/app.go
+++ b/amprobe/service/app.go
@@ -6,14 +6,14 @@ package service
 
 import (
 	"amprobe/service/middleware"
-	// "amprobe/web"
-	// "net/http"
+	"amprobe/web"
+	"net/http"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/compress"
 	"github.com/gofiber/fiber/v2/middleware/cors"
 
-	// "github.com/gofiber/fiber/v2/middleware/filesystem"
+	"github.com/gofiber/fiber/v2/middleware/filesystem"
 	"github.com/gofiber/fiber/v2/middleware/pprof"
 )
 
@@ -34,11 +34,11 @@ func NewFiberApp(config *Config, r IRouter) *fiber.App {
 	app.Use(middleware.PanicMiddleware())
 	app.Use(middleware.StackMiddleware)
 
-	// app.Use("/", filesystem.New(filesystem.Config{
-	// 	Root:       http.FS(web.FS),
-	// 	PathPrefix: "/dist",
-	// 	Browse:     true,
-	// }))
+	app.Use("/", filesystem.New(filesystem.Config{
+		Root:       http.FS(web.FS),
+		PathPrefix: "/dist",
+		Browse:     true,
+	}))
 
 	err := r.Register(app)
 	if err != nil {

--- a/amprobe/service/app.go
+++ b/amprobe/service/app.go
@@ -6,14 +6,14 @@ package service
 
 import (
 	"amprobe/service/middleware"
-	"amprobe/web"
-	"net/http"
+	// "amprobe/web"
+	// "net/http"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/compress"
 	"github.com/gofiber/fiber/v2/middleware/cors"
 
-	"github.com/gofiber/fiber/v2/middleware/filesystem"
+	// "github.com/gofiber/fiber/v2/middleware/filesystem"
 	"github.com/gofiber/fiber/v2/middleware/pprof"
 )
 
@@ -34,11 +34,11 @@ func NewFiberApp(config *Config, r IRouter) *fiber.App {
 	app.Use(middleware.PanicMiddleware())
 	app.Use(middleware.StackMiddleware)
 
-	app.Use("/", filesystem.New(filesystem.Config{
-		Root:       http.FS(web.FS),
-		PathPrefix: "/dist",
-		Browse:     true,
-	}))
+	// app.Use("/", filesystem.New(filesystem.Config{
+	// 	Root:       http.FS(web.FS),
+	// 	PathPrefix: "/dist",
+	// 	Browse:     true,
+	// }))
 
 	err := r.Register(app)
 	if err != nil {

--- a/amprobe/service/websocket.go
+++ b/amprobe/service/websocket.go
@@ -53,6 +53,7 @@ func (l *LoggerHandler) Handler(c *websocket.Conn) {
 			break
 		}
 		for scanner.Scan() {
+			slog.Info("%s container log: %s", containerId, string(scanner.Bytes()[8:]))
 			// scanner.Bytes() 前有 8 个字节的 the HEADER part,需要忽略掉
 			// https://medium.com/@dhanushgopinath/reading-docker-container-logs-with-golang-docker-engine-api-702233fac044
 			if err = c.WriteMessage(mt, scanner.Bytes()[8:]); err != nil {

--- a/amprobe/web/package.json
+++ b/amprobe/web/package.json
@@ -13,8 +13,9 @@
     },
     "dependencies": {
         "@element-plus/icons-vue": "^2.3.1",
-        "ansi_up": "^6.0.2",
         "axios": "^1.7.9",
+        "codemirror": "^5",
+        "codemirror-editor-vue3": "^2.8.0",
         "echarts": "^5.5.0",
         "echarts-liquidfill": "^3.1.0",
         "element-plus": "^2.9.3",
@@ -29,6 +30,7 @@
     "devDependencies": {
         "@antfu/eslint-config": "^3.14.0",
         "@iconify-json/ep": "^1.2.2",
+        "@types/codemirror": "^5.60.15",
         "@types/lodash-es": "^4.17.12",
         "@types/node": "^20.11.30",
         "@unocss/eslint-plugin": "^65.4.2",

--- a/amprobe/web/package.json
+++ b/amprobe/web/package.json
@@ -13,6 +13,7 @@
     },
     "dependencies": {
         "@element-plus/icons-vue": "^2.3.1",
+        "ansi_up": "^6.0.2",
         "axios": "^1.7.9",
         "echarts": "^5.5.0",
         "echarts-liquidfill": "^3.1.0",

--- a/amprobe/web/src/config/theme.ts
+++ b/amprobe/web/src/config/theme.ts
@@ -10,7 +10,7 @@ export const themeConfig: Record<Theme.ThemeType, { [ key: string ]: string }> =
         // 菜单样式#f4f0f0
         '--el-menu-bg-color': '#eff1f5',
         '--el-menu-hover-bg-color': '#71c4ef',
-        '--el-menu-active-bg-color': '#d4eaf7',
+        '--el-menu-active-bg-color': '#409eff',
         '--el-menu-text-color': '#3b3c3d',
         '--el-menu-active-color': '#00668c',
         '--el-menu-hover-text-color': '#00668c',

--- a/amprobe/web/src/config/theme.ts
+++ b/amprobe/web/src/config/theme.ts
@@ -8,7 +8,7 @@
 export const themeConfig: Record<Theme.ThemeType, { [ key: string ]: string }> = {
     light: {
         // 菜单样式#f4f0f0
-        '--el-menu-bg-color': '#f4f0f0',
+        '--el-menu-bg-color': '#eff1f5',
         '--el-menu-hover-bg-color': '#71c4ef',
         '--el-menu-active-bg-color': '#d4eaf7',
         '--el-menu-text-color': '#3b3c3d',

--- a/amprobe/web/src/config/theme.ts
+++ b/amprobe/web/src/config/theme.ts
@@ -12,8 +12,8 @@ export const themeConfig: Record<Theme.ThemeType, { [ key: string ]: string }> =
         '--el-menu-hover-bg-color': '#71c4ef',
         '--el-menu-active-bg-color': '#409eff',
         '--el-menu-text-color': '#3b3c3d',
-        '--el-menu-active-color': '#00668c',
-        '--el-menu-hover-text-color': '#00668c',
+        '--el-menu-active-color': '#ffffff',
+        '--el-menu-hover-text-color': '#ffffff',
         '--el-menu-horizontal-sub-item-height': '50px',
         // 侧边栏样式
         '--el-aside-logo-text-color': '#303133',

--- a/amprobe/web/src/config/theme.ts
+++ b/amprobe/web/src/config/theme.ts
@@ -9,7 +9,7 @@ export const themeConfig: Record<Theme.ThemeType, { [ key: string ]: string }> =
     light: {
         // 菜单样式#f4f0f0
         '--el-bg-color': '#f0f1f5',
-        '--el-menu-bg-color': '#eff1f5',
+        '--el-menu-bg-color': '#ffffff',
         '--el-menu-hover-bg-color': '#71c4ef',
         '--el-menu-active-bg-color': '#409eff',
         '--el-menu-text-color': '#3b3c3d',

--- a/amprobe/web/src/config/theme.ts
+++ b/amprobe/web/src/config/theme.ts
@@ -7,8 +7,8 @@
 // * 主题配置
 export const themeConfig: Record<Theme.ThemeType, { [ key: string ]: string }> = {
     light: {
-        // 菜单样式
-        '--el-menu-bg-color': '#fffefb',
+        // 菜单样式#f4f0f0
+        '--el-menu-bg-color': '#f4f0f0',
         '--el-menu-hover-bg-color': '#71c4ef',
         '--el-menu-active-bg-color': '#d4eaf7',
         '--el-menu-text-color': '#3b3c3d',

--- a/amprobe/web/src/config/theme.ts
+++ b/amprobe/web/src/config/theme.ts
@@ -8,6 +8,7 @@
 export const themeConfig: Record<Theme.ThemeType, { [ key: string ]: string }> = {
     light: {
         // 菜单样式#f4f0f0
+        '--el-bg-color': '#f0f1f5',
         '--el-menu-bg-color': '#eff1f5',
         '--el-menu-hover-bg-color': '#71c4ef',
         '--el-menu-active-bg-color': '#409eff',
@@ -27,7 +28,8 @@ export const themeConfig: Record<Theme.ThemeType, { [ key: string ]: string }> =
     },
     dark: {
         // 菜单样式
-        '--el-menu-bg-color': '#141414',
+        '--el-bg-color': '#141414',
+        '--el-menu-bg-color': '#1d1e1f',
         '--el-menu-hover-bg-color': '#000000',
         '--el-menu-active-bg-color': '#000000',
         '--el-menu-text-color': '#dadada',

--- a/amprobe/web/src/languages/modules/en.ts
+++ b/amprobe/web/src/languages/modules/en.ts
@@ -121,6 +121,10 @@ export default {
         restartContainer: 'Restart Container',
         delete: 'Delete',
         deleteContainer: 'Delete Container',
+        confirmStop: 'Confirm Stop?',
+        confirmDelete: 'Confirm Delete?',
+        confirmStart: 'Confirm Start?',
+        confirmRestart: 'Confirm Restart?',
     },
     image: {
         pullImage: 'Pull Image',

--- a/amprobe/web/src/languages/modules/zh.ts
+++ b/amprobe/web/src/languages/modules/zh.ts
@@ -118,6 +118,10 @@ export default {
         restartContainer: '重启容器',
         delete: '删除',
         deleteContainer: '删除容器',
+        confirmStop: '确认停止容器?',
+        confirmDelete: '确认删除容器?',
+        confirmStart: '确认启动容器?',
+        confirmRestart: '确认重启容器?',
     },
     image: {
         pullImage: '拉取镜像',

--- a/amprobe/web/src/layout/content/index.vue
+++ b/amprobe/web/src/layout/content/index.vue
@@ -20,6 +20,6 @@
   box-sizing: border-box;
 
   color: var(--el-header-text-color);
-  background-color: var(--el-menu-bg-color);
+  background-color: var(--el-bg-color);
 }
 </style>

--- a/amprobe/web/src/layout/content/index.vue
+++ b/amprobe/web/src/layout/content/index.vue
@@ -20,6 +20,6 @@
   box-sizing: border-box;
 
   color: var(--el-header-text-color);
-  background-color: var(--el-header-bg-color);
+  background-color: var(--el-menu-bg-color);
 }
 </style>

--- a/amprobe/web/src/layout/index.vue
+++ b/amprobe/web/src/layout/index.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import Content from '@/layout/content/index.vue';
 import Navbar from '@/layout/navbar/index.vue';
-import Sidebar from '@/layout/sidebar/index.vue'; /* PartiallyEnd: #3632/scriptSetup.vue */
-import Sidebar from '@/layout/sidebar/index.vue'
+import Sidebar from '@/layout/sidebar/index.vue';
 </script>
 
 <template>
@@ -41,7 +40,7 @@ import Sidebar from '@/layout/sidebar/index.vue'
   height: 100%;
   margin-left: 16px;
   border-radius: 4px;
-  background-color: var(--el-menu-bg-color);
+  background-color: var(--el-bg-color);
   overflow-y: scroll;
 }
 </style>

--- a/amprobe/web/src/layout/index.vue
+++ b/amprobe/web/src/layout/index.vue
@@ -30,7 +30,7 @@ import Sidebar from '@/layout/sidebar/index.vue'
   height: 100%;
   transition: 0.5s;
   border-right: var(--el-aside-border-color) 1px solid;
-  background-color: '#fff';
+  background-color: #ffffff;
 }
 
 @include b(layout-main) {

--- a/amprobe/web/src/layout/index.vue
+++ b/amprobe/web/src/layout/index.vue
@@ -30,7 +30,7 @@ import Sidebar from '@/layout/sidebar/index.vue'
   height: 100%;
   transition: 0.5s;
   border-right: var(--el-aside-border-color) 1px solid;
-  background-color: var(--el-menu-bg-color);
+  background-color: '#fff';
 }
 
 @include b(layout-main) {

--- a/amprobe/web/src/layout/index.vue
+++ b/amprobe/web/src/layout/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import Content from '@/layout/content/index.vue'
-import Navbar from '@/layout/navbar/index.vue'
+import Content from '@/layout/content/index.vue';
+import Navbar from '@/layout/navbar/index.vue';
+import Sidebar from '@/layout/sidebar/index.vue'; /* PartiallyEnd: #3632/scriptSetup.vue */
 import Sidebar from '@/layout/sidebar/index.vue'
 </script>
 
@@ -20,7 +21,7 @@ import Sidebar from '@/layout/sidebar/index.vue'
 @include b(layout) {
   width: 100%;
   height: 100%;
-  background-color: var(--el-menu-bg-color);
+  background-color: var(--el-bg-color);
   overflow: hidden;
 }
 
@@ -30,7 +31,7 @@ import Sidebar from '@/layout/sidebar/index.vue'
   height: 100%;
   transition: 0.5s;
   border-right: var(--el-aside-border-color) 1px solid;
-  background-color: #ffffff;
+  background-color: var(--el-menu-bg-color);
 }
 
 @include b(layout-main) {

--- a/amprobe/web/src/layout/navbar/index.vue
+++ b/amprobe/web/src/layout/navbar/index.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import Avatar from '@/layout/navbar/Avatar.vue'
-import Breadcrumb from './Breadcrumb.vue'
-import ThemeChange from '@/layout/navbar/ThemeChange.vue'
-import Language from '@/layout/navbar/Language.vue'
+import Avatar from '@/layout/navbar/Avatar.vue';
+import Language from '@/layout/navbar/Language.vue'; /* PartiallyEnd: #3632/scriptSetup.vue */
+import ThemeChange from '@/layout/navbar/ThemeChange.vue';
+import Breadcrumb from './Breadcrumb.vue';
 </script>
 
 <template>
@@ -25,7 +25,7 @@ import Language from '@/layout/navbar/Language.vue'
   width: 100%;
   padding: 0 16px;
   color: var(--el-header-text-color);
-  background-color: var(--el-header-bg-color);
+  background-color: var(--el-menu-bg-color);
   border-radius: 4px;
   border-bottom: 1px solid var(--el-header-border-color);
   border-left: 1px solid var(--el-header-border-color);

--- a/amprobe/web/src/layout/sidebar/Menuitem.vue
+++ b/amprobe/web/src/layout/sidebar/Menuitem.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { RouteRecordRaw } from 'vue-router'
-import { useI18n } from 'vue-i18n'
+import { useI18n } from 'vue-i18n';
+import type { RouteRecordRaw } from 'vue-router';
 
 defineProps<{
   items: RouteRecordRaw[]
@@ -33,35 +33,35 @@ function handleClickMenu(item: RouteRecordRaw) {
 </template>
 
 <style scoped lang="scss">
-.el-menu {
+/* .el-menu {
   &.el-menu--vertical {
     color: var(--el-menu-hover-text-color);
-    background-color: '#fff';
+    background-color: var(--el-menu-bg-color);
   }
 }
 
 .el-sub-menu {
-  background-color: '#fff';
+  background-color: var(--el-menu-bg-color);
   &:hover {
     color: var(--el-menu-hover-text-color);
   }
   &.is-active {
     color: var(--el-menu-active-color);
-    background-color: var(--el-menu-active-bg-color);
+    background-color: var(--el-menu-bg-color);
   }
 }
 
 .el-menu-item {
-  background-color: '#fff';
+  background-color: var(--el-menu-bg-color);
 
   &:hover {
     color: var(--el-menu-hover-text-color);
   }
   &.is-active {
     color: var(--el-menu-active-color);
-    background-color: var(--el-menu-active-bg-color);
+    background-color: var(--el-menu-bg-color);
   }
-}
+} */
 
 /* 文字单行省略号 */
 @include b(sle) {

--- a/amprobe/web/src/layout/sidebar/Menuitem.vue
+++ b/amprobe/web/src/layout/sidebar/Menuitem.vue
@@ -36,12 +36,12 @@ function handleClickMenu(item: RouteRecordRaw) {
 .el-menu {
   &.el-menu--vertical {
     color: var(--el-menu-hover-text-color);
-    background-color: var(--el-menu-bg-color);
+    background-color: '#fff';
   }
 }
 
 .el-sub-menu {
-  background-color: var(--el-menu-bg-color);
+  background-color: '#fff';
   &:hover {
     color: var(--el-menu-hover-text-color);
   }
@@ -52,7 +52,7 @@ function handleClickMenu(item: RouteRecordRaw) {
 }
 
 .el-menu-item {
-  background-color: var(--el-menu-bg-color);
+  background-color: '#fff';
 
   &:hover {
     color: var(--el-menu-hover-text-color);

--- a/amprobe/web/src/layout/sidebar/index.vue
+++ b/amprobe/web/src/layout/sidebar/index.vue
@@ -77,8 +77,13 @@ const menus = computed(() => {
 
 @include b(menu) {
   height: calc(100vh - 64px);
-  .el-menu {
+  :deep(.el-menu) {
     border: none !important;
+  }
+  :deep(.el-menu-item) {
+    margin: 0 !important;
+  }
+  :deep(.el-sub-menu) {
     margin: 0 !important;
   }
 }

--- a/amprobe/web/src/layout/sidebar/index.vue
+++ b/amprobe/web/src/layout/sidebar/index.vue
@@ -49,7 +49,7 @@ const menus = computed(() => {
 
 <style scoped lang="scss">
 .el-aside {
-  background-color: var(--el-menu-bg-color);
+  background-color: '#fff';
   //border-right: 1px solid var(--el-aside-border-color);
 }
 
@@ -85,7 +85,7 @@ const menus = computed(() => {
 @include b(collapse) {
   width: 12px;
   height: 32px;
-  background: var(--el-menu-bg-color);
+  background: '#fff';
   border-radius: 0 5px 5px 0;
   display: flex;
   justify-content: center;

--- a/amprobe/web/src/layout/sidebar/index.vue
+++ b/amprobe/web/src/layout/sidebar/index.vue
@@ -49,7 +49,7 @@ const menus = computed(() => {
 
 <style scoped lang="scss">
 .el-aside {
-  background-color: '#fff';
+  background-color: #ffffff;
   //border-right: 1px solid var(--el-aside-border-color);
 }
 
@@ -85,7 +85,7 @@ const menus = computed(() => {
 @include b(collapse) {
   width: 12px;
   height: 32px;
-  background: '#fff';
+  background: #ffffff;
   border-radius: 0 5px 5px 0;
   display: flex;
   justify-content: center;

--- a/amprobe/web/src/layout/sidebar/index.vue
+++ b/amprobe/web/src/layout/sidebar/index.vue
@@ -79,6 +79,7 @@ const menus = computed(() => {
   height: calc(100vh - 64px);
   .el-menu {
     border: none !important;
+    margin: 0 !important;
   }
 }
 

--- a/amprobe/web/src/layout/sidebar/index.vue
+++ b/amprobe/web/src/layout/sidebar/index.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import Menuitem from '@/layout/sidebar/Menuitem.vue'
-import useStore from '@/store'
-import { dynamicRoutes } from '@/router/dynamic.ts'
 import CollapseIcon from '@/layout/sidebar/CollapseIcon.vue'
+import Menuitem from '@/layout/sidebar/Menuitem.vue'
+import { dynamicRoutes } from '@/router/dynamic.ts'
+import useStore from '@/store'
 
 const currentRoute = useRoute()
 const store = useStore()
@@ -49,7 +49,7 @@ const menus = computed(() => {
 
 <style scoped lang="scss">
 .el-aside {
-  background-color: #ffffff;
+  background-color: var(--el-menu-bg-color);
   //border-right: 1px solid var(--el-aside-border-color);
 }
 
@@ -91,7 +91,7 @@ const menus = computed(() => {
 @include b(collapse) {
   width: 12px;
   height: 32px;
-  background: #ffffff;
+  background: var(--el-menu-bg-color);
   border-radius: 0 5px 5px 0;
   display: flex;
   justify-content: center;

--- a/amprobe/web/src/styles/bem.scss
+++ b/amprobe/web/src/styles/bem.scss
@@ -66,23 +66,23 @@ $modifier-sel: '--' !default;
     overflow: auto;
     margin: 8px 0;
     color: var(--el-menu-text-color);
-    // background-color: '#fff';
+    background-color: var(--el-menu-bg-color);
 
     .el-table {
-        // background-color: '#fff' !important;
+        background-color: var(--el-menu-bg-color);
         color: var(--el-menu-text-color);
         //
     }
 
     .el-table__header th {
-        // background-color: var(--el-menu-bg-color) !important;
+        background-color: var(--el-menu-bg-color) !important;
         color: var(--el-menu-text-color) !important;
     }
 
     .el-table__row {
-        // background-color: var(--el-menu-bg-color);
+        background-color: var(--el-menu-bg-color);
         color: var(--el-menu-text-color);
-        //border: 1px solid var(--el-header-border-color);
+        // border: 1px solid var(--el-header-border-color);
     }
 }
 

--- a/amprobe/web/src/styles/bem.scss
+++ b/amprobe/web/src/styles/bem.scss
@@ -51,7 +51,8 @@ $modifier-sel: '--' !default;
     :deep(.el-card) {
         height: 100%;
         color: var(--el-menu-text-color);
-        background-color: var(--el-menu-bg-color);
+        background-color: '#fff';
+
         :deep(.el-card__body) {
             height: 100%;
         }
@@ -65,20 +66,21 @@ $modifier-sel: '--' !default;
     overflow: auto;
     margin: 8px 0;
     color: var(--el-menu-text-color);
-    background-color: var(--el-menu-bg-color);
+    // background-color: '#fff';
 
     .el-table {
-        background-color: var(--el-menu-bg-color) !important;
+        // background-color: '#fff' !important;
         color: var(--el-menu-text-color);
         //
     }
 
     .el-table__header th {
-        background-color: var(--el-menu-bg-color) !important;
+        // background-color: var(--el-menu-bg-color) !important;
         color: var(--el-menu-text-color) !important;
     }
+
     .el-table__row {
-        background-color: var(--el-menu-bg-color);
+        // background-color: var(--el-menu-bg-color);
         color: var(--el-menu-text-color);
         //border: 1px solid var(--el-header-border-color);
     }
@@ -91,7 +93,7 @@ $modifier-sel: '--' !default;
     height: 36px;
     width: 100%;
     color: var(--el-menu-text-color);
-    background-color: var(--el-menu-bg-color);
+    // background-color: var(--el-menu-bg-color);
 }
 
 @include b(pagination) {
@@ -99,7 +101,7 @@ $modifier-sel: '--' !default;
     align-items: center;
     justify-content: flex-end;
     color: var(--el-menu-text-color);
-    background-color: var(--el-menu-bg-color);
+    // background-color: var(--el-menu-bg-color);
 }
 
 @include b(description) {

--- a/amprobe/web/src/styles/element.scss
+++ b/amprobe/web/src/styles/element.scss
@@ -62,7 +62,7 @@
 
 
 .el-menu {
-    background-color: #ffffff !important;
+    background-color: var(--el-menu-bg-color) !important;
 
     .el-menu-item,
     .el-sub-menu {
@@ -86,8 +86,8 @@
         box-shadow: 0 2px 8px rgba(64, 158, 255, 0.2);
         transition: all 0.3s cubic-bezier(0.215, 0.61, 0.355, 1);
     }
+}
 
-    .el-sub-menu.is-active {
-        background: none !important;
-    }
+el-table {
+    background-color: var(--el-menu-bg-color) !important;
 }

--- a/amprobe/web/src/styles/element.scss
+++ b/amprobe/web/src/styles/element.scss
@@ -59,3 +59,31 @@
         height: 100% !important;
     }
 }
+
+
+.el-menu {
+
+    .el-menu-item,
+    .el-sub-menu {
+        margin: 4px 12px;
+    }
+
+    .el-menu-item,
+    .el-sub-menu__title,
+    .el-sub-menu .el-menu-item {
+        transition: all 0.3s cubic-bezier(0.895, 0.03, 0.685, 0.22);
+    }
+
+    .el-menu-item:hover,
+    .el-menu-item.is-active,
+    .el-sub-menu__title:hover,
+    .el-sub-menu .el-menu-item:hover,
+    .el-sub-menu .el-menu-item.is-active {
+        background: #409EFF;
+        color: #fff;
+        border-radius: 8px;
+        transform: translateY(-1px);
+        box-shadow: 0 2px 8px rgba(64, 158, 255, 0.2);
+        transition: all 0.3s cubic-bezier(0.215, 0.61, 0.355, 1);
+    }
+}

--- a/amprobe/web/src/styles/element.scss
+++ b/amprobe/web/src/styles/element.scss
@@ -1,5 +1,5 @@
 :root {
-    --el-menu-bg-color: #FFFEFB;
+    // --el-menu-bg-color: #FFFEFB;
     --el-color-primary: #D4EAF8;
 }
 
@@ -51,7 +51,7 @@
 .el-card {
     height: 100%;
     color: var(--el-menu-text-color) !important;
-    background-color: var(--el-menu-bg-color) !important;
+    // background-color: var(--el-menu-bg-color) !important;
 
     :deep(.el-card__body) {
         display: flex;
@@ -62,6 +62,7 @@
 
 
 .el-menu {
+    background-color: '#fff';
 
     .el-menu-item,
     .el-sub-menu {
@@ -79,10 +80,9 @@
     .el-sub-menu__title:hover,
     .el-sub-menu .el-menu-item:hover,
     .el-sub-menu .el-menu-item.is-active {
-        background: #409EFF;
+        background: #9bd7fb;
         color: #fff;
         border-radius: 8px;
-        transform: translateY(-1px);
         box-shadow: 0 2px 8px rgba(64, 158, 255, 0.2);
         transition: all 0.3s cubic-bezier(0.215, 0.61, 0.355, 1);
     }

--- a/amprobe/web/src/styles/element.scss
+++ b/amprobe/web/src/styles/element.scss
@@ -62,7 +62,7 @@
 
 
 .el-menu {
-    background-color: '#fff';
+    background-color: #ffffff !important;
 
     .el-menu-item,
     .el-sub-menu {
@@ -80,10 +80,14 @@
     .el-sub-menu__title:hover,
     .el-sub-menu .el-menu-item:hover,
     .el-sub-menu .el-menu-item.is-active {
-        background: #9bd7fb;
+        background: #409eff;
         color: #fff;
         border-radius: 8px;
         box-shadow: 0 2px 8px rgba(64, 158, 255, 0.2);
         transition: all 0.3s cubic-bezier(0.215, 0.61, 0.355, 1);
+    }
+
+    .el-sub-menu.is-active {
+        background: none !important;
     }
 }

--- a/amprobe/web/src/styles/reset.scss
+++ b/amprobe/web/src/styles/reset.scss
@@ -6,10 +6,12 @@
     border-style: solid;
     border-width: 0;
 }
+
 #app {
     height: 100%;
     width: 100%;
 }
+
 html {
     box-sizing: border-box;
     width: 100%;
@@ -18,6 +20,7 @@ html {
     tab-size: 4;
     text-size-adjust: 100%;
 }
+
 body {
     width: 100%;
     height: 100%;
@@ -30,28 +33,34 @@ body {
     text-rendering: optimizelegibility;
     overflow: hidden;
 }
+
 a {
     color: inherit;
     text-decoration: inherit;
 }
+
 img,
 svg {
     display: inline-block;
 }
+
 svg {
     vertical-align: -0.15em; // 因icon大小被设置为和字体大小一致，而span等标签的下边缘会和字体的基线对齐，故需设置一个往下的偏移比例，来纠正视觉上的未对齐效果
 }
+
 ul,
 li {
     padding: 0;
     margin: 0;
     list-style: none;
 }
+
 *,
 *::before,
 *::after {
     box-sizing: inherit;
 }
+
 a,
 a:focus,
 a:hover {
@@ -59,6 +68,7 @@ a:hover {
     text-decoration: none;
     cursor: pointer;
 }
+
 a:focus,
 a:active,
 div:focus {

--- a/amprobe/web/src/views/account/api/index.vue
+++ b/amprobe/web/src/views/account/api/index.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
+import { queryResource } from '@/api/account'
 import { useTable } from '@/hooks/useTable.ts'
 import type { TableInstance } from 'element-plus'
 import { useI18n } from 'vue-i18n'
-import { queryResource } from '@/api/account'
 
 const tableRef = ref<TableInstance>()
 const { tableData, loading, search } = useTable(queryResource, {}, false)
@@ -21,7 +21,7 @@ const { t } = useI18n()
                 v-loading="loading"
                 :data="tableData"
                 height="100%"
-                :header-cell-style="{ height: '45px', fontSize: '14px', color: '#000', background: '#fafafa' }"
+                :header-cell-style="{ height: '45px', fontSize: '14px', color: '#000'}"
                 border
             >
                 <el-table-column prop="name" label="接口名称" min-width="100" />

--- a/amprobe/web/src/views/container/container/components/ViewLog.vue
+++ b/amprobe/web/src/views/container/container/components/ViewLog.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
-import { Websocket } from '@/components/Websocket'
-import { useI18n } from 'vue-i18n'
+import { Websocket } from '@/components/Websocket';
+import { AnsiUp } from 'ansi_up';
+import { useI18n } from 'vue-i18n';
+
+const ansi_up = new AnsiUp();
 
 const props = defineProps<{
   visible: boolean
@@ -44,7 +47,7 @@ function viewLog(container_id: string): void {
 
   const onMessage = (ws: Websocket, ev: MessageEvent) => {
     console.log(ws)
-    logData.value = `${logData.value}\n${ev.data}`
+    logData.value = `${logData.value}\n${ansi_up.ansi_to_html(ev.data)}`
   }
 
   ws = new Websocket(`ws/${container_id}`, onOpen, onMessage)

--- a/amprobe/web/src/views/container/container/components/ViewLog.vue
+++ b/amprobe/web/src/views/container/container/components/ViewLog.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
 import { Websocket } from '@/components/Websocket';
-import { AnsiUp } from 'ansi_up';
 import { useI18n } from 'vue-i18n';
 
-const ansi_up = new AnsiUp();
+import Codemirror from "codemirror-editor-vue3";
+import "codemirror/mode/javascript/javascript.js";
+
+const cmOptions = {
+  mode: "log",
+  theme: "default",
+
+}
 
 const props = defineProps<{
   visible: boolean
@@ -47,7 +53,7 @@ function viewLog(container_id: string): void {
 
   const onMessage = (ws: Websocket, ev: MessageEvent) => {
     console.log(ws)
-    logData.value = `${logData.value}\n${ansi_up.ansi_to_html(ev.data)}`
+    logData.value = `${logData.value}\n${ev.data}`
   }
 
   ws = new Websocket(`ws/${container_id}`, onOpen, onMessage)
@@ -85,7 +91,13 @@ const { t } = useI18n()
 <template>
     <!--  查看日志弹窗  -->
     <el-dialog v-model="dialogVisible" :title="t('container.log')" width="50%" :destroy-on-close="true">
-        <el-input v-model="logData" :rows="20" type="textarea" />
+        <Codemirror
+            v-model:value="logData"
+            :options="cmOptions"
+            border
+            height="100%"
+            width="100%"
+        />
         <template #footer>
             <div class="dialog-footer">
                 <el-button size="small" type="primary" plain @click="downloadLog">

--- a/amprobe/web/src/views/container/container/index.vue
+++ b/amprobe/web/src/views/container/container/index.vue
@@ -1,23 +1,23 @@
 <script setup lang="ts">
-import zhCn from 'element-plus/es/locale/lang/zh-cn'
-import type { TableInstance } from 'element-plus'
 import type { Container } from '@/interface/container.ts'
+import type { TableInstance } from 'element-plus'
+import zhCn from 'element-plus/es/locale/lang/zh-cn'
 
-import { useTable } from '@/hooks/useTable.ts'
 import { queryContainers } from '@/api/container'
+import { useTable } from '@/hooks/useTable.ts'
 
 import useCommandComponent from '@/hooks/useCommandComponent.ts'
 import AddContainer from '@/views/container/container/components/AddContainer.vue'
+import DeleteContainer from '@/views/container/container/components/DeleteContainer.vue'
+import RestartContainer from '@/views/container/container/components/RestartContainer.vue'
 import StartContainer from '@/views/container/container/components/StartContainer.vue'
 import StopContainer from '@/views/container/container/components/StopContainer.vue'
-import RestartContainer from '@/views/container/container/components/RestartContainer.vue'
-import DeleteContainer from '@/views/container/container/components/DeleteContainer.vue'
 import ViewLog from '@/views/container/container/components/ViewLog.vue'
 
-import { useI18n } from 'vue-i18n'
 import useStore from '@/store'
-import en from 'element-plus/es/locale/lang/en'
 import { getBrowserLanguage } from '@/utils'
+import en from 'element-plus/es/locale/lang/en'
+import { useI18n } from 'vue-i18n'
 
 const { tableData, pageable, loading, search, handleSizeChange, handleCurrentChange } = useTable(queryContainers)
 onMounted(async () => {
@@ -68,7 +68,7 @@ const locale = computed(() => {
                 ref="tableRef"
                 v-loading="loading"
                 :data="tableData as Container[]"
-                :header-cell-style="{ height: '45px', fontSize: '14px', color: '#000', background: '#fafafa' }"
+                :header-cell-style="{ height: '45px', fontSize: '14px', color: '#000' }"
                 height="100%"
                 border
                 @selection-change="handleSelectionChange"

--- a/amprobe/web/src/views/container/image/index.vue
+++ b/amprobe/web/src/views/container/image/index.vue
@@ -1,21 +1,21 @@
 <script setup lang="ts">
 import zhCn from 'element-plus/es/locale/lang/zh-cn'
 
-import type { TableInstance } from 'element-plus'
 import type { Image } from '@/interface/container.ts'
+import type { TableInstance } from 'element-plus'
 
 import useCommandComponent from '@/hooks/useCommandComponent.ts'
-import PullImage from '@/views/container/image/components/PullImage.vue'
+import DeleteImage from '@/views/container/image/components/DeleteImage.vue'
 import ImportImage from '@/views/container/image/components/ImportImage.vue'
 import PruneImage from '@/views/container/image/components/PruneImage.vue'
-import DeleteImage from '@/views/container/image/components/DeleteImage.vue'
+import PullImage from '@/views/container/image/components/PullImage.vue'
 
-import { useTable } from '@/hooks/useTable'
 import { queryImages } from '@/api/container'
-import { useI18n } from 'vue-i18n'
+import { useTable } from '@/hooks/useTable'
 import useStore from '@/store'
-import en from 'element-plus/es/locale/lang/en'
 import { getBrowserLanguage } from '@/utils'
+import en from 'element-plus/es/locale/lang/en'
+import { useI18n } from 'vue-i18n'
 
 const { tableData, pageable, loading, search, handleSizeChange, handleCurrentChange } = useTable(queryImages)
 onMounted(async () => {
@@ -69,7 +69,7 @@ const locale = computed(() => {
                 ref="tableRef"
                 v-loading="loading"
                 :data="tableData as Image[]"
-                :header-cell-style="{ height: '45px', fontSize: '14px', color: '#000', background: '#fafafa' }"
+                :header-cell-style="{ height: '45px', fontSize: '14px', color: '#000' }"
                 height="100%"
                 border
                 @selection-change="handleSelectionChange"

--- a/amprobe/web/src/views/container/network/index.vue
+++ b/amprobe/web/src/views/container/network/index.vue
@@ -10,10 +10,10 @@ import useCommandComponent from '@/hooks/useCommandComponent.ts'
 import AddNetwork from '@/views/container/network/components/AddNetwork.vue'
 import DeleteNetwork from '@/views/container/network/components/DeleteNetwork.vue'
 
-import { useI18n } from 'vue-i18n'
 import useStore from '@/store'
-import en from 'element-plus/es/locale/lang/en'
 import { getBrowserLanguage } from '@/utils'
+import en from 'element-plus/es/locale/lang/en'
+import { useI18n } from 'vue-i18n'
 
 const { tableData, pageable, loading, search, handleSizeChange, handleCurrentChange } = useTable(queryNetworks)
 onMounted(async () => {
@@ -55,7 +55,7 @@ const locale = computed(() => {
                 ref="tableRef"
                 v-loading="loading"
                 :data="tableData as Network[]"
-                :header-cell-style="{ height: '45px', fontSize: '14px', color: '#000', background: '#fafafa' }"
+                :header-cell-style="{ height: '45px', fontSize: '14px', color: '#000' }"
                 height="100%"
                 border
                 @selection-change="handleSelectionChange"

--- a/amprobe/web/src/views/overview/index.vue
+++ b/amprobe/web/src/views/overview/index.vue
@@ -197,7 +197,7 @@ onMounted(async () => {
   @include e(card) {
     margin-bottom: 8px;
     height: 140px;
-    background-color: var(--el-menu-active-bg-color) !important;
+    //background-color: var(--el-menu-active-bg-color) !important;
   }
 }
 

--- a/amprobe/web/src/views/profile/index.vue
+++ b/amprobe/web/src/views/profile/index.vue
@@ -53,7 +53,7 @@ const { t } = useI18n()
     justify-content: space-between;
     height: 48px;
     width: 100%;
-    background-color: var(--el-menu-bg-color);
+    // background-color: var(--el-menu-bg-color);
     // box-shadow: 0 1px 4px rgba(0, 21, 41, 0.08);
 
     border-radius: 4px;

--- a/amprobe/web/types/auto-imports.d.ts
+++ b/amprobe/web/types/auto-imports.d.ts
@@ -7,8 +7,6 @@ export {}
 declare global {
   const EffectScope: typeof import('vue')['EffectScope']
   const ElMessage: typeof import('element-plus/es')['ElMessage']
-  const ElMessageBox: typeof import('element-plus/es')['ElMessageBox']
-  const ElNotification: typeof import('element-plus/es')['ElNotification']
   const acceptHMRUpdate: typeof import('pinia')['acceptHMRUpdate']
   const computed: typeof import('vue')['computed']
   const createApp: typeof import('vue')['createApp']

--- a/amvector/Makefile
+++ b/amvector/Makefile
@@ -22,7 +22,7 @@ wire: assets
 
 .PHONY: amd64
 # build amd64
-amd64: wire assets
+amd64: assets
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(TARGET) $(SERVER)
 
 .PHONY: arm64
@@ -32,7 +32,7 @@ arm64: wire assets
 
 .PHONY: installer
 # generate installer
-installer: wire
+installer:
 	@mkdir -p $(OBJPATH)
 	@cp $(TARGET) $(OBJPATH)
 	@strip $(OBJPATH)/$(TARGET)

--- a/amvector/assets/resources/amprobe/nginx/conf.d/amprobe.conf
+++ b/amvector/assets/resources/amprobe/nginx/conf.d/amprobe.conf
@@ -1,0 +1,20 @@
+server {
+    listen       80;
+    server_name _;
+
+    location / {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP      $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass http://127.0.0.1:8000;
+    }
+
+    location /ws/ {
+        # rewrite ^/wsUrl/(.*)$ /$1 break; # 拦截标识去除
+        proxy_pass http://127.0.0.1:8000/ws/;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}

--- a/amvector/assets/resources/amprobe/nginx/nginx.conf
+++ b/amvector/assets/resources/amprobe/nginx/nginx.conf
@@ -1,0 +1,33 @@
+worker_processes 2;
+daemon off;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer"'
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    error_log /app/logs/error.log warn;
+    access_log /app/logs/access.log main;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+
+    proxy_connect_timeout 240s;
+    proxy_send_timeout 240s;
+    proxy_read_timeout 240s;
+
+    client_max_body_size 64m;
+    client_body_buffer_size 64m;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/amvector/cmd/amvector/setup.go
+++ b/amvector/cmd/amvector/setup.go
@@ -42,13 +42,24 @@ func setupConfig(prefix, configFile string) error {
 }
 
 func setupResources(prefix string) error {
-	amprobeDir := filepath.Join(prefix, resources.RootPath, resources.AmprobeConfigFolder)
-	if err := utils.EnsureDirExists(amprobeDir); err != nil {
+	amprobeConfigDir := filepath.Join(prefix, resources.RootPath, resources.AmprobeConfigFolder)
+	if err := utils.EnsureDirExists(amprobeConfigDir); err != nil {
 		return err
 	}
 	if err := assets.CopyDir(
 		filepath.Join(assets.ResourcesDir, resources.AmprobeConfigFolder),
-		amprobeDir,
+		amprobeConfigDir,
+	); err != nil {
+		return err
+	}
+
+	amprobeNginxDir := filepath.Join(prefix, resources.RootPath, resources.AmprobeNginxFolder)
+	if err := utils.EnsureDirExists(amprobeNginxDir); err != nil {
+		return err
+	}
+	if err := assets.CopyDir(
+		filepath.Join(assets.ResourcesDir, resources.AmprobeNginxFolder),
+		amprobeNginxDir,
 	); err != nil {
 		return err
 	}

--- a/amvector/pkg/compose/compose.go
+++ b/amvector/pkg/compose/compose.go
@@ -68,6 +68,8 @@ func DockerComposeConfig() DockerCompose {
 	volumes := []string{
 		"/data/amprobe/resources/amprobe/configs:/app/configs",
 		"/data/amprobe/resources/amvector/socks/vector.sock:/app/vector.sock",
+		"/data/amprobe/resources/amprobe/nginx/conf.d:/etc/nginx/conf.d",
+		"/data/amprobe/resources/amprobe/nginx/nginx.conf:/etc/nginx/nginx.conf",
 		"/data/amprobe/logs/amprobe:/app/logs",
 	}
 	dockerCompose.Services.Amprobe.Volumes = append(

--- a/amvector/pkg/compose/compose.go
+++ b/amvector/pkg/compose/compose.go
@@ -28,7 +28,7 @@ type DockerCompose struct {
 					MaxFile string `yaml:"max-file" default:"10"`
 				} `yaml:"options"`
 			} `yaml:"logging"`
-			Ports       []string `yaml:"ports" default:"[80:80,443:443]"`
+			Ports       []string `yaml:"ports" default:"[80:80]"`
 			Environment struct {
 				CreatedByProbe string `yaml:"CREATED_BY_PROBE" default:"true"`
 			} `yaml:"environment"`

--- a/amvector/pkg/resources/resources.go
+++ b/amvector/pkg/resources/resources.go
@@ -20,4 +20,5 @@ var (
 
 	AmprobeFolder       = "amprobe"
 	AmprobeConfigFolder = filepath.Join(AmprobeFolder, "configs")
+	AmprobeNginxFolder  = filepath.Join(AmprobeFolder, "nginx")
 )


### PR DESCRIPTION
`v1.3.10` 版本进行了重构，采用了全新的 `UI` 设计（目前看着可能还是没有那么炫酷，但对比之前还是有所进步，自恋ing）。重构后的变化如下：

- 将前端+后端统一打包成了一个二进制文件，之前的版本中，在 `amprobe` 容器中使用 `nginx` 对前、后端服务分别部署。优化后牺牲了一定的灵活性，但从整体性上来说更易于维护，同时保留了 `nginx` 用于配置域名转发。
- 新增了容器监控页，目前仅支持监控各个容器的 `CPU` 和内存使用
- 精简了容器管理中的列表展示项，将部分功能转移到了容器监控页
- 新增主题切换功能，支持切换黑暗主题
- 新增 `i18n` 国际化功能，支持切换至英文页面
- 支持 `amprobe` 端口占用修改
- 容器日志高亮显示