### PR TITLE
docs: 官网域名统一为 beacon.amuluze.com

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -46,11 +46,11 @@
 - **Collia Agent** collects host and Docker metrics, reports monitoring batches over HTTP, and opens a reverse gRPC tunnel for Server-initiated control calls.
 - Query and control requests must explicitly select an Agent, preventing implicit fallback or cross-node reads.
 
-Website: [help.beacon.amuluze.com](https://help.beacon.amuluze.com) · Repository: [github.com/amuluze/beacon](https://github.com/amuluze/beacon)
+Website: [beacon.amuluze.com](https://beacon.amuluze.com) · Repository: [github.com/amuluze/beacon](https://github.com/amuluze/beacon)
 
 ## 🖼️ Screenshot
 
-See the live product at [help.beacon.amuluze.com](https://help.beacon.amuluze.com) for screenshots.
+See the live product at [beacon.amuluze.com](https://beacon.amuluze.com) for screenshots.
 
 
 ## ✨ Features
@@ -105,7 +105,7 @@ See each module's `README.md` and source comments for the complete boundaries an
 ### Online installer (recommended)
 
 ```bash
-bash -c "$(curl -fsSLk https://help.beacon.amuluze.com/release/latest/manager.sh)"
+bash -c "$(curl -fsSLk https://beacon.amuluze.com/release/latest/manager.sh)"
 ```
 
 The installer guides you through Web port, Agent control port, and security credential configuration.
@@ -172,7 +172,7 @@ beacon/
 └── go.work                 # Go workspace definition
 ```
 
-> Note: the marketing site, deployment manifests, and SDD docs are not part of this open-source repository. See [help.beacon.amuluze.com](https://help.beacon.amuluze.com).
+> Note: the marketing site, deployment manifests, and SDD docs are not part of this open-source repository. See [beacon.amuluze.com](https://beacon.amuluze.com).
 
 ## 🧑‍💻 Development and Contributing
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@
 - **Collia Agent** 采集主机和 Docker 指标，通过 HTTP 上报监控批次，并主动建立反向 gRPC tunnel 接收 Server 控制调用。
 - 查询与控制请求必须显式指定 Agent，避免默认节点回退或跨节点读取。
 
-官网：[help.beacon.amuluze.com](https://help.beacon.amuluze.com) · 仓库：[github.com/amuluze/beacon](https://github.com/amuluze/beacon)
+官网：[beacon.amuluze.com](https://beacon.amuluze.com) · 仓库：[github.com/amuluze/beacon](https://github.com/amuluze/beacon)
 
 ## 🖼️ 产品截图
 
-详细界面截图请访问官网 [help.beacon.amuluze.com](https://help.beacon.amuluze.com)。
+详细界面截图请访问官网 [beacon.amuluze.com](https://beacon.amuluze.com)。
 
 ## ✨ 功能特性
 
@@ -104,7 +104,7 @@ Beacon 将三条路径明确分离：
 ### 在线安装（推荐）
 
 ```bash
-bash -c "$(curl -fsSLk https://help.beacon.amuluze.com/release/latest/manager.sh)"
+bash -c "$(curl -fsSLk https://beacon.amuluze.com/release/latest/manager.sh)"
 ```
 
 安装脚本会引导配置 Web 端口、Agent 控制端口与安全凭据。
@@ -171,7 +171,7 @@ beacon/
 └── go.work                 # Go workspace 定义
 ```
 
-> 注：官网、部署清单、SDD 文档等周边资产不在本开源仓库内，参见 [help.beacon.amuluze.com](https://help.beacon.amuluze.com)。
+> 注：官网、部署清单、SDD 文档等周边资产不在本开源仓库内，参见 [beacon.amuluze.com](https://beacon.amuluze.com)。
 
 ## 🧑‍💻 开发与贡献
 


### PR DESCRIPTION
将 README 中官网与安装脚本地址由 help.beacon.amuluze.com 更新为 beacon.amuluze.com。